### PR TITLE
ブクマ追加時にTwitterに投稿可能にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 /build
 /captures
 /app/src/main/assets/hatena.json
+/app/src/main/assets/twitter.json
 /app/keystore/
+/app/src/debug/
 /app/src/release/
 /app/app-release.apk
 /gradle.properties

--- a/app/app.iml
+++ b/app/app.iml
@@ -84,12 +84,17 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.crashlytics.sdk.android/beta/1.1.4/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.crashlytics.sdk.android/crashlytics-core/2.3.8/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.crashlytics.sdk.android/crashlytics/2.5.5/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.digits.sdk.android/digits/1.9.2/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.jakewharton.rxbinding/rxbinding-appcompat-v7-kotlin/0.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.jakewharton.rxbinding/rxbinding-appcompat-v7/0.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.jakewharton.rxbinding/rxbinding-kotlin/0.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.jakewharton.rxbinding/rxbinding-support-v4-kotlin/0.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.jakewharton.rxbinding/rxbinding-support-v4/0.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.jakewharton.rxbinding/rxbinding/0.3.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.twitter.sdk.android/tweet-composer/1.0.2/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.twitter.sdk.android/tweet-ui/1.8.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.twitter.sdk.android/twitter-core/1.6.2/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.twitter.sdk.android/twitter/1.11.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.fabric.sdk.android/fabric/1.3.10/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.reactivex/rxandroid/1.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
@@ -108,45 +113,52 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" scope="TEST" name="espresso-idling-resource-2.2.1" level="project" />
     <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
-    <orderEntry type="library" exported="" name="kotlin-runtime-1.0.0-beta-4583" level="project" />
-    <orderEntry type="library" exported="" name="jsoup-1.8.3" level="project" />
-    <orderEntry type="library" exported="" name="picasso-2.5.2" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-library-1.3" level="project" />
+    <orderEntry type="library" exported="" name="retrofit-1.8.0" level="project" />
+    <orderEntry type="library" exported="" name="digits-1.9.2" level="project" />
+    <orderEntry type="library" exported="" name="recyclerview-v7-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="rxbinding-appcompat-v7-0.3.0" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="appcompat-v7-23.1.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="runner-0.4.1" level="project" />
+    <orderEntry type="library" exported="" name="commons-codec-1.3" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="javax.annotation-api-1.2" level="project" />
+    <orderEntry type="library" exported="" name="beta-1.1.4" level="project" />
+    <orderEntry type="library" exported="" name="rxbinding-support-v4-0.3.0" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="javawriter-2.1.1" level="project" />
+    <orderEntry type="library" exported="" name="signpost-core-1.2.1.2" level="project" />
+    <orderEntry type="library" exported="" name="rxbinding-0.3.0" level="project" />
+    <orderEntry type="library" exported="" name="tweet-composer-1.0.2" level="project" />
+    <orderEntry type="library" exported="" name="twitter-core-1.6.2" level="project" />
+    <orderEntry type="library" exported="" name="answers-1.3.6" level="project" />
+    <orderEntry type="library" exported="" name="twitter-1.11.0" level="project" />
+    <orderEntry type="library" exported="" name="picasso-2.5.2" level="project" />
+    <orderEntry type="library" exported="" name="jsoup-1.8.3" level="project" />
+    <orderEntry type="library" exported="" name="kotlin-runtime-1.0.0-beta-4583" level="project" />
     <orderEntry type="library" exported="" name="kotlinx.dom-0.0.5" level="project" />
     <orderEntry type="library" exported="" name="okhttp-2.6.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-integration-1.3" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-23.1.1" level="project" />
-    <orderEntry type="library" exported="" name="rxbinding-appcompat-v7-0.3.0" level="project" />
+    <orderEntry type="library" exported="" name="tweet-ui-1.8.0" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.1.1" level="project" />
     <orderEntry type="library" exported="" name="rxbinding-support-v4-kotlin-0.3.0" level="project" />
     <orderEntry type="library" exported="" name="kotlin-stdlib-1.0.0-beta-4583" level="project" />
     <orderEntry type="library" exported="" name="rxbinding-appcompat-v7-kotlin-0.3.0" level="project" />
     <orderEntry type="library" exported="" name="otto-1.3.8" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-23.1.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="jsr305-2.0.1" level="project" />
     <orderEntry type="library" exported="" name="fabric-1.3.10" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="espresso-core-2.2.1" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="runner-0.4.1" level="project" />
     <orderEntry type="library" exported="" name="gson-2.4" level="project" />
-    <orderEntry type="library" exported="" name="commons-codec-1.3" level="project" />
     <orderEntry type="library" exported="" name="rxbinding-kotlin-0.3.0" level="project" />
     <orderEntry type="library" exported="" name="crashlytics-2.5.5" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="javax.annotation-api-1.2" level="project" />
     <orderEntry type="library" exported="" name="crashlytics-core-2.3.8" level="project" />
-    <orderEntry type="library" exported="" name="beta-1.1.4" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="javax.inject-1" level="project" />
-    <orderEntry type="library" exported="" name="rxbinding-support-v4-0.3.0" level="project" />
     <orderEntry type="library" exported="" name="rxandroid-1.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="rules-0.4.1" level="project" />
     <orderEntry type="library" exported="" name="rxjava-1.1.0" level="project" />
     <orderEntry type="library" exported="" name="design-23.1.1" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="javawriter-2.1.1" level="project" />
+    <orderEntry type="library" exported="" name="twitter-text-1.13.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="exposed-instrumentation-api-publish-0.4.1" level="project" />
-    <orderEntry type="library" exported="" name="signpost-core-1.2.1.2" level="project" />
-    <orderEntry type="library" exported="" name="rxbinding-0.3.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
-    <orderEntry type="library" exported="" name="answers-1.3.6" level="project" />
   </component>
 </module>

--- a/app/app.iml
+++ b/app/app.iml
@@ -132,9 +132,9 @@
     <orderEntry type="library" exported="" name="twitter-core-1.6.2" level="project" />
     <orderEntry type="library" exported="" name="answers-1.3.6" level="project" />
     <orderEntry type="library" exported="" name="twitter-1.11.0" level="project" />
+    <orderEntry type="library" exported="" name="kotlin-runtime-1.0.0-beta-4583" level="project" />
     <orderEntry type="library" exported="" name="picasso-2.5.2" level="project" />
     <orderEntry type="library" exported="" name="jsoup-1.8.3" level="project" />
-    <orderEntry type="library" exported="" name="kotlin-runtime-1.0.0-beta-4583" level="project" />
     <orderEntry type="library" exported="" name="kotlinx.dom-0.0.5" level="project" />
     <orderEntry type="library" exported="" name="okhttp-2.6.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-integration-1.3" level="project" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,6 +84,9 @@ dependencies {
     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true;
     }
+    compile('com.twitter.sdk.android:twitter:1.11.0@aar') {
+        transitive = true;
+    }
 }
 buildscript {
     ext.kotlin_version = '1.0.0-beta-4583'

--- a/app/src/main/assets/twitter_dummy.json
+++ b/app/src/main/assets/twitter_dummy.json
@@ -1,0 +1,4 @@
+{
+  "consumer_key": "XXXXXXXXXX",
+  "consumer_secret": "XXXXXXXXXXXXXXXXXXXXX"
+}

--- a/app/src/main/java/me/rei_m/hbfavmaterial/App.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/App.kt
@@ -16,7 +16,7 @@ public class App : Application() {
 
         // Set up Crashlytics
         if (!BuildConfig.DEBUG) {
-            Fabric.with(this, Crashlytics());
+            Fabric.with(this, Crashlytics())
         }
 
         // ModelLocatorにModelの参照を登録
@@ -29,6 +29,7 @@ public class App : Application() {
             register(Tag.OTHERS_BOOKMARK, BookmarkUserModel())
             register(Tag.USER_REGISTER_BOOKMARK, UserRegisterBookmarkModel())
             register(Tag.HATENA, HatenaModel(applicationContext))
+            register(Tag.TWITTER, TwitterModel(applicationContext))
         }
     }
 

--- a/app/src/main/java/me/rei_m/hbfavmaterial/activities/SettingActivity.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/activities/SettingActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.support.design.widget.NavigationView
 import android.view.MenuItem
 import com.squareup.otto.Subscribe
+import com.twitter.sdk.android.core.TwitterAuthConfig
 import me.rei_m.hbfavmaterial.App
 import me.rei_m.hbfavmaterial.R
 import me.rei_m.hbfavmaterial.events.ui.UserIdChangedEvent
@@ -29,7 +30,7 @@ public class SettingActivity : BaseActivityWithDrawer() {
         findViewById(R.id.pager).hide()
         findViewById(R.id.content).show()
         if (savedInstanceState == null) {
-            setFragment(SettingFragment.newInstance())
+            setFragment(SettingFragment.newInstance(), SettingFragment.TAG)
         }
 
         val navigationView = findViewById(R.id.activity_main_nav) as NavigationView
@@ -55,6 +56,14 @@ public class SettingActivity : BaseActivityWithDrawer() {
         }
 
         return super.onNavigationItemSelected(item)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == TwitterAuthConfig.DEFAULT_AUTH_REQUEST_CODE) {
+            val fragment = supportFragmentManager.findFragmentByTag(SettingFragment.TAG)
+            fragment?.onActivityResult(requestCode, resultCode, data)
+        }
     }
 
     @Subscribe

--- a/app/src/main/java/me/rei_m/hbfavmaterial/entities/TwitterSessionEntity.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/entities/TwitterSessionEntity.kt
@@ -1,0 +1,10 @@
+package me.rei_m.hbfavmaterial.entities
+
+import java.io.Serializable
+
+/**
+ * TwitterSessionのEntity.
+ */
+public data class TwitterSessionEntity(var userId: Long = 0,
+                                       var userName: String = "",
+                                       var oAuthTokenEntity: OAuthTokenEntity) : Serializable

--- a/app/src/main/java/me/rei_m/hbfavmaterial/extensions/FragmentExtension.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/extensions/FragmentExtension.kt
@@ -1,8 +1,6 @@
 package me.rei_m.hbfavmaterial.extensions
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import android.support.v4.app.Fragment
 
 /**

--- a/app/src/main/java/me/rei_m/hbfavmaterial/fragments/SettingFragment.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/fragments/SettingFragment.kt
@@ -17,9 +17,11 @@ import me.rei_m.hbfavmaterial.activities.OAuthActivity
 import me.rei_m.hbfavmaterial.events.EventBusHolder
 import me.rei_m.hbfavmaterial.events.ui.UserIdChangedEvent
 import me.rei_m.hbfavmaterial.events.ui.UserIdCheckedEvent
+import me.rei_m.hbfavmaterial.extensions.getAppContext
 import me.rei_m.hbfavmaterial.extensions.showSnackbarNetworkError
 import me.rei_m.hbfavmaterial.managers.ModelLocator
 import me.rei_m.hbfavmaterial.models.HatenaModel
+import me.rei_m.hbfavmaterial.models.TwitterModel
 import me.rei_m.hbfavmaterial.models.UserModel
 import me.rei_m.hbfavmaterial.utils.ConstantUtil
 
@@ -67,15 +69,12 @@ public class SettingFragment : Fragment() {
         }
 
         val buttonTwitterLogin = view.findViewById(R.id.login_button) as TwitterLoginButton
+        val context = getAppContext()
         buttonTwitterLogin.callback = object : Callback<TwitterSession>() {
             override fun success(result: Result<TwitterSession>?) {
                 result ?: return
-                // twitterModelに保存.
-                println(result.data)
-                println(result.data.userId)
-                println(result.data.userName)
-                println(result.data.authToken.secret)
-                println(result.data.authToken.token)
+                val twitterModel = ModelLocator.get(ModelLocator.Companion.Tag.TWITTER) as TwitterModel
+                twitterModel.saveSession(context, result.data)
             }
 
             override fun failure(exception: TwitterException?) {

--- a/app/src/main/java/me/rei_m/hbfavmaterial/fragments/SettingFragment.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/fragments/SettingFragment.kt
@@ -10,6 +10,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import com.squareup.otto.Subscribe
+import com.twitter.sdk.android.core.*
+import com.twitter.sdk.android.core.identity.TwitterLoginButton
 import me.rei_m.hbfavmaterial.R
 import me.rei_m.hbfavmaterial.activities.OAuthActivity
 import me.rei_m.hbfavmaterial.events.EventBusHolder
@@ -27,6 +29,9 @@ import me.rei_m.hbfavmaterial.utils.ConstantUtil
 public class SettingFragment : Fragment() {
 
     companion object {
+
+        public val TAG = SettingFragment::class.java.simpleName
+
         public fun newInstance(): SettingFragment {
             return SettingFragment()
         }
@@ -61,6 +66,23 @@ public class SettingFragment : Fragment() {
             startActivityForResult(OAuthActivity.createIntent(activity), ConstantUtil.REQ_CODE_OAUTH)
         }
 
+        val buttonTwitterLogin = view.findViewById(R.id.login_button) as TwitterLoginButton
+        buttonTwitterLogin.callback = object : Callback<TwitterSession>() {
+            override fun success(result: Result<TwitterSession>?) {
+                result ?: return
+                // twitterModelに保存.
+                println(result.data)
+                println(result.data.userId)
+                println(result.data.userName)
+                println(result.data.authToken.secret)
+                println(result.data.authToken.token)
+            }
+
+            override fun failure(exception: TwitterException?) {
+
+            }
+        }
+
         return view
     }
 
@@ -79,6 +101,14 @@ public class SettingFragment : Fragment() {
 
         data ?: return
 
+        if (requestCode == TwitterAuthConfig.DEFAULT_AUTH_REQUEST_CODE) {
+            // Fabric SDKからのTwitter認可後の処理を行う.
+            val buttonTwitterLogin = view.findViewById(R.id.login_button) as TwitterLoginButton
+            buttonTwitterLogin.onActivityResult(requestCode, resultCode, data);
+            return
+        }
+
+        // はてなのOAuth以外のリクエストの場合は終了.
         if (requestCode != ConstantUtil.REQ_CODE_OAUTH) {
             return
         }

--- a/app/src/main/java/me/rei_m/hbfavmaterial/managers/ModelLocator.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/managers/ModelLocator.kt
@@ -16,6 +16,7 @@ public class ModelLocator private constructor() {
             OTHERS_BOOKMARK,
             USER_REGISTER_BOOKMARK,
             HATENA,
+            TWITTER,
         }
 
         public fun register(tag: Tag, model: Any): Unit {

--- a/app/src/main/java/me/rei_m/hbfavmaterial/models/HatenaModel.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/models/HatenaModel.kt
@@ -265,7 +265,7 @@ public class HatenaModel {
     }
 
     /**
-     * PreferencesにModel内の
+     * Preferencesを取得する
      */
     private fun getPreferences(context: Context): SharedPreferences {
         return context.getAppPreferences(HatenaModel::class.java.simpleName)

--- a/app/src/main/java/me/rei_m/hbfavmaterial/models/TwitterModel.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/models/TwitterModel.kt
@@ -1,0 +1,79 @@
+package me.rei_m.hbfavmaterial.models
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.twitter.sdk.android.Twitter
+import com.twitter.sdk.android.core.TwitterAuthConfig
+import com.twitter.sdk.android.core.TwitterSession
+import io.fabric.sdk.android.Fabric
+import me.rei_m.hbfavmaterial.entities.OAuthTokenEntity
+import me.rei_m.hbfavmaterial.entities.TwitterSessionEntity
+import me.rei_m.hbfavmaterial.extensions.getAppPreferences
+import me.rei_m.hbfavmaterial.extensions.getAssetToJson
+
+/**
+ * はてなのOAuth関連の情報を管理するModel.
+ */
+public class TwitterModel {
+
+    public var isBusy = false
+        private set
+
+    public var twitterSessionEntity: TwitterSessionEntity? = null
+        private set
+
+    companion object {
+        private val KEY_PREF_TWITTER_SESSION = "KEY_PREF_TWITTER_SESSION"
+    }
+
+    /**
+     * コンストラクタ.
+     */
+    constructor(context: Context) {
+
+        // OAuth認証用のキーを作成し、OAuthAPIを作成する.
+        val twitterJson = context.getAssetToJson("twitter.json")
+        val authConfig = TwitterAuthConfig(twitterJson.getString("consumer_key"), twitterJson.getString("consumer_secret"))
+        Fabric.with(context, Twitter(authConfig))
+
+        //mHatenaOAuthApi = HatenaOAuthApi(hatenaJson.getString("consumer_key"), hatenaJson.getString("consumer_secret"))
+
+        // Preferencesからアクセストークンを復元する.
+        val pref = getPreferences(context)
+        val twitterSessionJsonString = pref.getString(KEY_PREF_TWITTER_SESSION, null)
+        if (twitterSessionJsonString != null) {
+            twitterSessionEntity = Gson().fromJson(twitterSessionJsonString, TwitterSessionEntity::class.java)
+        }
+    }
+
+    public fun saveSession(context: Context, twitterSession: TwitterSession) {
+
+        twitterSessionEntity = TwitterSessionEntity(
+                userId = twitterSession.userId,
+                userName = twitterSession.userName,
+                oAuthTokenEntity = OAuthTokenEntity(
+                        token = twitterSession.authToken.token,
+                        secretToken = twitterSession.authToken.secret
+                )
+        )
+        saveSession(context)
+    }
+
+    /**
+     * PreferencesにModel内のセッション情報を保存する.
+     */
+    private fun saveSession(context: Context) {
+        getPreferences(context)
+                .edit()
+                .putString(KEY_PREF_TWITTER_SESSION, Gson().toJson(twitterSessionEntity))
+                .apply()
+    }
+
+    /**
+     * Preferencesを取得する
+     */
+    private fun getPreferences(context: Context): SharedPreferences {
+        return context.getAppPreferences(TwitterModel::class.java.simpleName)
+    }
+}

--- a/app/src/main/java/me/rei_m/hbfavmaterial/models/TwitterModel.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/models/TwitterModel.kt
@@ -1,11 +1,14 @@
 package me.rei_m.hbfavmaterial.models
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import com.google.gson.Gson
 import com.twitter.sdk.android.Twitter
-import com.twitter.sdk.android.core.TwitterAuthConfig
-import com.twitter.sdk.android.core.TwitterSession
+import com.twitter.sdk.android.core.*
+import com.twitter.sdk.android.core.identity.TwitterAuthClient
+import com.twitter.sdk.android.core.models.Tweet
 import io.fabric.sdk.android.Fabric
 import me.rei_m.hbfavmaterial.entities.OAuthTokenEntity
 import me.rei_m.hbfavmaterial.entities.TwitterSessionEntity
@@ -23,8 +26,12 @@ public class TwitterModel {
     public var twitterSessionEntity: TwitterSessionEntity? = null
         private set
 
+    public var isShare: Boolean = false
+        private set
+
     companion object {
         private val KEY_PREF_TWITTER_SESSION = "KEY_PREF_TWITTER_SESSION"
+        private val KEY_PREF_IS_SHARE_TWITTER = "KEY_PREF_IS_SHARE_TWITTER"
     }
 
     /**
@@ -37,17 +44,104 @@ public class TwitterModel {
         val authConfig = TwitterAuthConfig(twitterJson.getString("consumer_key"), twitterJson.getString("consumer_secret"))
         Fabric.with(context, Twitter(authConfig))
 
-        //mHatenaOAuthApi = HatenaOAuthApi(hatenaJson.getString("consumer_key"), hatenaJson.getString("consumer_secret"))
-
         // Preferencesからアクセストークンを復元する.
         val pref = getPreferences(context)
         val twitterSessionJsonString = pref.getString(KEY_PREF_TWITTER_SESSION, null)
         if (twitterSessionJsonString != null) {
             twitterSessionEntity = Gson().fromJson(twitterSessionJsonString, TwitterSessionEntity::class.java)
+            twitterSessionEntity?.apply {
+                val token = TwitterAuthToken(oAuthTokenEntity.token, oAuthTokenEntity.secretToken)
+                Twitter.getSessionManager().activeSession = TwitterSession(token, userId, userName)
+            }
         }
+        isShare = pref.getBoolean(KEY_PREF_IS_SHARE_TWITTER, false)
     }
 
-    public fun saveSession(context: Context, twitterSession: TwitterSession) {
+    /**
+     * OAuth認証済か判定する.
+     */
+    public fun isAuthorised(): Boolean {
+        return Twitter.getSessionManager().activeSession != null
+    }
+
+    /**
+     * OAuth認証を行う.
+     */
+    public fun authorize(activity: Activity) {
+
+        if (isBusy) {
+            return
+        }
+
+        isBusy = true
+
+        TwitterAuthClient().authorize(activity, object : Callback<TwitterSession>() {
+            override fun success(result: Result<TwitterSession>?) {
+                result ?: return
+                saveSession(activity.applicationContext, result.data)
+            }
+
+            override fun failure(exception: TwitterException?) {
+            }
+        })
+    }
+
+    /**
+     * OAuth認証後のコールバック処理を行う.
+     */
+    public fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        isBusy = false
+        TwitterAuthClient().onActivityResult(requestCode, resultCode, data)
+    }
+
+    /**
+     * Busyフラグをクリアする.
+     */
+    public fun clearBusy() {
+        isBusy = false
+    }
+
+    /**
+     * ツイートを投稿する.
+     */
+    public fun postTweet(text: String) {
+
+        if (isBusy) {
+            return
+        }
+
+        isBusy = true
+
+        Twitter.getApiClient().statusesService.update(text,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                null,
+                object : Callback<Tweet>() {
+                    override fun success(result: Result<Tweet>?) {
+                        isBusy = false
+                        result ?: return
+                    }
+
+                    override fun failure(exception: TwitterException?) {
+                        isBusy = false
+                    }
+                })
+    }
+
+    public fun setIsShare(context: Context, value: Boolean) {
+        isShare = value
+        saveIsShare(context)
+    }
+
+    /**
+     * セッションを保存する.
+     */
+    private fun saveSession(context: Context, twitterSession: TwitterSession) {
 
         twitterSessionEntity = TwitterSessionEntity(
                 userId = twitterSession.userId,
@@ -67,6 +161,13 @@ public class TwitterModel {
         getPreferences(context)
                 .edit()
                 .putString(KEY_PREF_TWITTER_SESSION, Gson().toJson(twitterSessionEntity))
+                .apply()
+    }
+
+    private fun saveIsShare(context: Context) {
+        getPreferences(context)
+                .edit()
+                .putBoolean(KEY_PREF_IS_SHARE_TWITTER, isShare)
                 .apply()
     }
 

--- a/app/src/main/java/me/rei_m/hbfavmaterial/utils/BookmarkUtil.kt
+++ b/app/src/main/java/me/rei_m/hbfavmaterial/utils/BookmarkUtil.kt
@@ -25,6 +25,14 @@ public class BookmarkUtil private constructor() {
             COMEDY
         }
 
+        fun createShareText(url: String, title: String, comment: String): String {
+            val text = "\"$title\" $url"
+            return if (0 < comment.length)
+                "$comment $text"
+            else
+                text
+        }
+
         fun getFilterTypeString(context: Context, filterType: FilterType): String {
 
             val id = when (filterType) {

--- a/app/src/main/res/layout/dialog_fragment_edit_bookmark.xml
+++ b/app/src/main/res/layout/dialog_fragment_edit_bookmark.xml
@@ -67,6 +67,19 @@
         android:textColor="@color/text_color_middle" />
 
     <android.support.v7.widget.SwitchCompat
+        android:id="@+id/dialog_fragment_edit_bookmark_switch_share_twitter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_marginBottom="@dimen/margin"
+        android:layout_marginLeft="@dimen/margin_outline_dialog"
+        android:layout_marginRight="@dimen/margin_outline_dialog"
+        android:background="@null"
+        android:checked="false"
+        android:text="@string/text_share_twitter"
+        android:textColor="@color/text_color_middle" />
+
+    <android.support.v7.widget.SwitchCompat
         android:id="@+id/dialog_fragment_edit_bookmark_switch_delete"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -93,10 +93,50 @@
 
     </LinearLayout>
 
-    <com.twitter.sdk.android.core.identity.TwitterLoginButton
-        android:id="@+id/login_button"
+    <FrameLayout
+        android:id="@+id/fragment_setting_layout_icon_twitter_oauth"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/fragment_setting_layout_text_hatena_oauth" />
+        android:layout_height="@dimen/height_item_two_column"
+        android:layout_below="@id/fragment_setting_layout_icon_hatena_oauth">
+
+        <android.support.v7.widget.AppCompatImageView
+            android:id="@+id/fragment_setting_image_icon_twitter_oauth"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginLeft="@dimen/margin_outline"
+            android:layout_marginStart="@dimen/margin_outline"
+            android:src="@drawable/ic_sync_grey_500_36dp" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:id="@+id/fragment_setting_layout_text_twitter_oauth"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/height_item_two_column"
+        android:layout_below="@id/fragment_setting_layout_text_hatena_oauth"
+        android:layout_marginLeft="@dimen/margin_content_from_screen"
+        android:layout_marginStart="@dimen/margin_content_from_screen"
+        android:background="@drawable/bg_border_bottom_accent"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:paddingEnd="@dimen/margin_outline"
+        android:paddingLeft="0dp"
+        android:paddingRight="@dimen/margin_outline"
+        android:paddingStart="0dp">
+
+        <android.support.v7.widget.AppCompatTextView
+            android:id="@+id/fragment_setting_text_title_twitter_oauth"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/text_twitter_account_connect"
+            android:textSize="@dimen/text_size_caption" />
+
+        <android.support.v7.widget.AppCompatTextView
+            android:id="@+id/fragment_setting_text_twitter_oauth"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/text_size_title" />
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -93,4 +93,10 @@
 
     </LinearLayout>
 
+    <com.twitter.sdk.android.core.identity.TwitterLoginButton
+        android:id="@+id/login_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/fragment_setting_layout_text_hatena_oauth" />
+
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,12 +40,14 @@
     <string name="text_hatena_account_connect">はてなブックマーク連携</string>
     <string name="text_hatena_account_connect_ok">連携中</string>
     <string name="text_hatena_account_connect_no">未連携</string>
+    <string name="text_twitter_account_connect">Twitter連携</string>
     <string name="text_opinion">ご意見・ご要望 - GitHub</string>
     <string name="text_version">バージョン</string>
     <string name="text_add_comment">コメントを追加</string>
     <string name="text_open">公開</string>
     <string name="text_not_open">非公開</string>
     <string name="text_delete">削除</string>
+    <string name="text_share_twitter">Twitterに投稿</string>
 
     <string name="button_setting">　 設定 　</string>
     <string name="button_add">　 追加 　</string>


### PR DESCRIPTION
# TODO
- [x] Fabric SDKを使ってTwitter OAuth認証を通す
- [x] TwitterModelを作成し、取得したトークンを保存する/起動時に復元する
- [x] 設定画面の表示を認証済/未認証で切り替える
- [x] はてブ追加時にTwitterのAPIにPOSTする処理を追加する
- [x] はてブ追加時の画面でTwitter投稿を選択できるようにする
